### PR TITLE
ACP-18: Implement Location updates via flows

### DIFF
--- a/app/src/main/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImpl.kt
@@ -72,6 +72,23 @@ class LocationRepositoryImpl(
             }
     }
 
+    private fun List<Location>.filterLocations(): List<Location> {
+        val startingVal = lastLocation ?: this[0]
+        return fold(mutableListOf(startingVal)) { acc, location ->
+            if (acc.last().hasAccuracy() && acc.last().distanceTo(location)/2 < acc.last().accuracy){
+                acc
+            } else {
+                acc.apply { add(location) }
+            }
+        }.apply {
+            if (lastLocation != null) {
+                removeAt(0)
+            } else {
+                lastLocation = last()
+            }
+        }
+    }
+
     companion object {
         const val REFRESH_INTERVAL_SECONDS = 3L
     }

--- a/app/src/main/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImpl.kt
@@ -22,7 +22,7 @@ class LocationRepositoryImpl(
     private val locationProvider: FusedLocationProviderClient,
 ) : LocationRepository {
 
-    private var locationCallback: LocationCallback? = null
+    internal var locationCallback: LocationCallback? = null
 
     private var lastLocation: Location? = null
 
@@ -77,9 +77,14 @@ class LocationRepositoryImpl(
     }
 
     private fun List<Location>.filterLocations(): List<Location> {
-        val startingVal = lastLocation ?: this[0]
-        return fold(mutableListOf(startingVal)) { acc, location ->
-            if (acc.last().hasAccuracy() && acc.last().distanceTo(location)/2 < acc.last().accuracy){
+        val startingVal = lastLocation?: get(0)
+        val startingIdx = if (lastLocation != null) -1 else 0
+        return foldIndexed(mutableListOf(startingVal)) { i, acc, location ->
+            if (
+                startingIdx == i
+                || acc.last().hasAccuracy()
+                && acc.last().distanceTo(location)/2 < acc.last().accuracy
+            ){
                 acc
             } else {
                 acc.apply { add(location) }

--- a/app/src/main/java/com/ignacnic/architectcoders/domain/location/LocationRepository.kt
+++ b/app/src/main/java/com/ignacnic/architectcoders/domain/location/LocationRepository.kt
@@ -1,10 +1,12 @@
 package com.ignacnic.architectcoders.domain.location
 
+import kotlinx.coroutines.flow.Flow
+
 interface LocationRepository {
 
-    fun requestLocationUpdates(onResult: (List<MyLocation>) -> Unit)
+    fun startLocationUpdates(): Flow<List<MyLocation>>
 
-    fun removeLocationUpdates()
+    fun stopLocationUpdates()
 
     suspend fun requestSingleLocation(onResult: (MyLocation?) -> Unit)
 }

--- a/app/src/main/java/com/ignacnic/architectcoders/ui/location/requester/LocationRequesterScreenViewModel.kt
+++ b/app/src/main/java/com/ignacnic/architectcoders/ui/location/requester/LocationRequesterScreenViewModel.kt
@@ -3,11 +3,13 @@ package com.ignacnic.architectcoders.ui.location.requester
 import android.Manifest
 import androidx.annotation.RequiresPermission
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.ignacnic.architectcoders.domain.location.LocationRepository
 import com.ignacnic.architectcoders.domain.location.MyLocation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class LocationRequesterScreenViewModel(
     private val locationRepository: LocationRepository
@@ -46,7 +48,7 @@ class LocationRequesterScreenViewModel(
     }
 
     private fun onStopUpdates() {
-        locationRepository.removeLocationUpdates()
+        locationRepository.stopLocationUpdates()
         _state.update{ it.copy(updatesRunning = false) }
     }
 
@@ -78,11 +80,13 @@ class LocationRequesterScreenViewModel(
                 locationRationaleNeeded = false,
             )
         }
-        locationRepository.requestLocationUpdates { locations ->
-            _state.update {
-                it.copy(
-                    locationUpdates = it.locationUpdates.plus(locations)
-                )
+        viewModelScope.launch {
+            locationRepository.startLocationUpdates().collect { locations ->
+                _state.update {
+                    it.copy(
+                        locationUpdates = it.locationUpdates.plus(locations)
+                    )
+                }
             }
         }
     }

--- a/app/src/test/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImplTest.kt
+++ b/app/src/test/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImplTest.kt
@@ -32,7 +32,7 @@ class LocationRepositoryImplTest {
 
     @Test
     fun `SHOULD do nothing WHEN remove updates is called GIVEN location callback is not initialized`() {
-        sut.removeLocationUpdates()
+        sut.stopLocationUpdates()
         verify(exactly = 0) {
             locationClient.removeLocationUpdates(any<LocationCallback>())
         }
@@ -41,7 +41,7 @@ class LocationRepositoryImplTest {
     @Test
     fun `SHOULD call remove updates WHEN remove updates is called GIVEN updates were requested`() {
         sut.requestLocationUpdates {}
-        sut.removeLocationUpdates()
+        sut.stopLocationUpdates()
         verify { locationClient.removeLocationUpdates(any<LocationCallback>()) }
     }
 

--- a/app/src/test/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImplTest.kt
+++ b/app/src/test/java/com/ignacnic/architectcoders/data/location/LocationRepositoryImplTest.kt
@@ -1,17 +1,25 @@
 package com.ignacnic.architectcoders.data.location
 
+import android.location.Location
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
+import com.google.android.gms.location.LocationResult
+import com.ignacnic.architectcoders.domain.location.MyLocation
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class LocationRepositoryImplTest {
     private lateinit var sut: LocationRepositoryImpl
 
@@ -23,11 +31,14 @@ class LocationRepositoryImplTest {
     }
 
     @Test
-    fun `SHOULD request location updates on client WHEN requestLocationUpdate invoked`() {
-        sut.requestLocationUpdates {}
+    fun `SHOULD request location updates on client WHEN requestLocationUpdate invoked`() = runTest {
+        val flow = sut.startLocationUpdates()
+        val collectJob = launch { flow.collect{} }
+        advanceUntilIdle()
         verify {
             locationClient.requestLocationUpdates(any(), any<LocationCallback>(), any())
         }
+        collectJob.cancel()
     }
 
     @Test
@@ -39,9 +50,22 @@ class LocationRepositoryImplTest {
     }
 
     @Test
-    fun `SHOULD call remove updates WHEN remove updates is called GIVEN updates were requested`() {
-        sut.requestLocationUpdates {}
+    fun `SHOULD call remove updates WHEN remove updates is called GIVEN updates were requested`() = runTest {
+        val flow = sut.startLocationUpdates()
+        val collectJob = launch { flow.collect{} }
+        advanceUntilIdle()
         sut.stopLocationUpdates()
+        verify { locationClient.removeLocationUpdates(any<LocationCallback>()) }
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `SHOULD call remove updates WHEN flow lost observer GIVEN updates were requested`() = runTest {
+        val flow = sut.startLocationUpdates()
+        val collectJob = launch { flow.collect{} }
+        advanceUntilIdle()
+        collectJob.cancel()
+        advanceUntilIdle()
         verify { locationClient.removeLocationUpdates(any<LocationCallback>()) }
     }
 
@@ -51,5 +75,65 @@ class LocationRepositoryImplTest {
         coVerify {
             locationClient.getCurrentLocation(any<Int>(), any())
         }
+    }
+
+    @Test
+    fun `SHOULD duplicated filtered locations WHEN startLocationUpdates GIVEN missing accuracy`() = runTest {
+        val flow = sut.startLocationUpdates()
+        val collectJob = launch { flow.collect{ result ->
+            Assert.assertEquals(MYLOCATION_EXPECTED_NO_ACC, result)
+        }}
+        advanceUntilIdle()
+        sut.locationCallback?.onLocationResult(LocationResult.create(LOCATION_LIST_WITHOUT_ACC))
+        advanceUntilIdle()
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `SHOULD correctly filtered locations WHEN startLocationUpdates GIVEN missing accuracy`() = runTest {
+        val flow = sut.startLocationUpdates()
+        val collectJob = launch { flow.collect{ result ->
+            Assert.assertEquals(MYLOCATION_EXPECTED, result)
+        }}
+        advanceUntilIdle()
+        sut.locationCallback?.onLocationResult(LocationResult.create(LOCATION_LIST_WITH_ACC))
+        advanceUntilIdle()
+        collectJob.cancel()
+    }
+
+    companion object {
+        private val LOCATION_LIST_WITHOUT_ACC = listOf(
+            Location("").apply {
+                latitude = 1.0
+                longitude = 2.0
+                time = 0L
+            },
+            Location("").apply {
+                latitude = 1.0
+                longitude = 2.0
+                time = 1L
+            },
+        )
+        private val MYLOCATION_EXPECTED_NO_ACC = listOf(
+            MyLocation("1.0", "2.0", "0"),
+            MyLocation("1.0", "2.0", "1"),
+        )
+        private val LOCATION_LIST_WITH_ACC = listOf(
+            Location("").apply {
+                latitude = 1.0
+                longitude = 2.0
+                time = 0L
+                accuracy = 10f
+            },
+            Location("").apply {
+                latitude = 1.0
+                longitude = 2.0
+                time = 1L
+                accuracy = 10f
+            },
+        )
+        private val MYLOCATION_EXPECTED = listOf(
+            MyLocation("1.0", "2.0", "0"),
+        )
     }
 }

--- a/app/src/test/java/com/ignacnic/architectcoders/ui/requester/LocationRequesterScreenViewModelTest.kt
+++ b/app/src/test/java/com/ignacnic/architectcoders/ui/requester/LocationRequesterScreenViewModelTest.kt
@@ -5,13 +5,19 @@ import com.ignacnic.architectcoders.domain.location.LocationRepository
 import com.ignacnic.architectcoders.domain.location.MyLocation
 import com.ignacnic.architectcoders.ui.location.requester.LocationRequesterScreenViewModel
 import com.ignacnic.architectcoders.ui.location.requester.LocationRequesterScreenViewModel.Action
+import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Test
@@ -21,6 +27,7 @@ class LocationRequesterScreenViewModelTest {
 
     private val locationRepository = mockk<LocationRepository>(relaxed = true)
     private val sut = LocationRequesterScreenViewModel(locationRepository)
+    private val locationFlow = MutableStateFlow(emptyList<MyLocation>())
 
     @Test
     fun `SHOULD have initial state WHEN viewModel is initialized`() {
@@ -65,7 +72,7 @@ class LocationRequesterScreenViewModelTest {
             mapOf(Manifest.permission.ACCESS_FINE_LOCATION to true)
         ))
         verify {
-            locationRepository.requestLocationUpdates(any())
+            locationRepository.startLocationUpdates()
         }
         stateValues[1].let { state ->
             Assert.assertTrue(state.updatesRunning)
@@ -102,11 +109,14 @@ class LocationRequesterScreenViewModelTest {
         Assert.assertFalse(sut.state.value.locationRationaleNeeded)
     }
 
-    private fun givenLocations(locations: List<MyLocation>) {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun TestScope.givenLocations(locations: List<MyLocation>) {
         every {
-            locationRepository.requestLocationUpdates(any())
-        } answers {
-            firstArg<(List<MyLocation>) -> Unit>().invoke(locations)
+            locationRepository.startLocationUpdates()
+        } returns locationFlow.also { flow ->
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                flow.emit(locations)
+            }
         }
     }
 

--- a/app/src/test/java/com/ignacnic/architectcoders/ui/requester/LocationRequesterScreenViewModelTest.kt
+++ b/app/src/test/java/com/ignacnic/architectcoders/ui/requester/LocationRequesterScreenViewModelTest.kt
@@ -82,7 +82,7 @@ class LocationRequesterScreenViewModelTest {
         sut.reduceAction(Action.UpdatesStopped)
         Assert.assertFalse(sut.state.value.updatesRunning)
         verify {
-            locationRepository.removeLocationUpdates()
+            locationRepository.stopLocationUpdates()
         }
     }
 


### PR DESCRIPTION
[ACP-18](https://inicolaslop.atlassian.net/browse/ACP-18)

Adding in this PR the changes pertinent to the substitution of callback-based location updates by Flows. Additionally, the test clases around the Location repository and the Location Requester Screen have been updated and the coverage has improved.