### PR TITLE
6th Project version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/snapshots/**/*.png filter=lfs diff=lfs merge=lfs -text

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -33,8 +33,12 @@ gradlePlugin {
             implementationClass = "com.ignacnic.convention.KotlinLibraryConventionPlugin"
         }
         create("unitTest") {
-            id = "com.ignacnic.convention.test" // This is the id we used to resolve our plugin.
+            id = "com.ignacnic.convention.test.unit" // This is the id we used to resolve our plugin.
             implementationClass = "com.ignacnic.convention.UnitTestConventionPlugin"
+        }
+        create("screenshotTest") {
+            id = "com.ignacnic.convention.test.screenshot" // This is the id we used to resolve our plugin.
+            implementationClass = "com.ignacnic.convention.ScreenshotTestConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/src/main/java/com/ignacnic/convention/ComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/ignacnic/convention/ComposeConventionPlugin.kt
@@ -39,6 +39,7 @@ class ComposeConventionPlugin : Plugin<Project> {
             add("implementation", libs.findLibrary("androidx-material3").get())
             add("implementation", libs.findLibrary("androidx-ui-test-manifest").get())
             add("implementation", libs.findLibrary("androidx-ui-test-junit4").get())
+            add("debugImplementation", libs.findLibrary("androidx-ui-tooling").get())
         }
     }
 }

--- a/build-logic/convention/src/main/java/com/ignacnic/convention/ScreenshotTestConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/ignacnic/convention/ScreenshotTestConventionPlugin.kt
@@ -1,0 +1,17 @@
+package com.ignacnic.convention
+
+import com.ignacnic.convention.utils.libs
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
+
+class ScreenshotTestConventionPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        with(project) {
+            dependencies {
+                add("testImplementation", libs.findLibrary("paparazzi").get())
+            }
+        }
+    }
+
+}

--- a/business-logic/elevation/build.gradle.kts
+++ b/business-logic/elevation/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.ignacnic.android.library)
     alias(libs.plugins.kotlinx.serialization)
-    alias(libs.plugins.ignacnic.test)
+    alias(libs.plugins.ignacnic.test.unit)
 }
 
 android {

--- a/business-logic/gpx-file/build.gradle.kts
+++ b/business-logic/gpx-file/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.ignacnic.kotlin.library)
-    alias(libs.plugins.ignacnic.test)
+    alias(libs.plugins.ignacnic.test.unit)
 }
 
 dependencies {

--- a/business-logic/location/build.gradle.kts
+++ b/business-logic/location/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.ignacnic.android.library)
-    alias(libs.plugins.ignacnic.test)
+    alias(libs.plugins.ignacnic.test.unit)
 }
 
 android {

--- a/business-logic/user-preferences/build.gradle.kts
+++ b/business-logic/user-preferences/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.ignacnic.android.library)
-    alias(libs.plugins.ignacnic.test)
+    alias(libs.plugins.ignacnic.test.unit)
 }
 
 android {

--- a/common/file-manager/build.gradle.kts
+++ b/common/file-manager/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     alias(libs.plugins.ignacnic.android.library)
-    alias(libs.plugins.ignacnic.test)
+    alias(libs.plugins.ignacnic.test.unit)
 }
 
 android {

--- a/common/ui-resources/build.gradle.kts
+++ b/common/ui-resources/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.ignacnic.android.library)
     alias(libs.plugins.ignacnic.compose)
+    alias(libs.plugins.ignacnic.test.screenshot)
+    alias(libs.plugins.paparazzi)
 }
 
 android {

--- a/common/ui-resources/src/test/java/com/ignacnic/architectcoders/common/uiresources/components/RationaleDialogTest.kt
+++ b/common/ui-resources/src/test/java/com/ignacnic/architectcoders/common/uiresources/components/RationaleDialogTest.kt
@@ -1,0 +1,24 @@
+package com.ignacnic.architectcoders.common.uiresources.components
+
+import androidx.compose.ui.res.stringResource
+import app.cash.paparazzi.Paparazzi
+import com.ignacnic.architectcoders.common.uiresources.R
+import com.ignacnic.architectcoders.common.uiresources.theme.ArchitectCodersTheme
+import org.junit.Rule
+import org.junit.Test
+
+class RationaleDialogTest {
+    @get:Rule
+    val paparazziTestRule by lazy { Paparazzi() }
+
+    @Test
+    fun testRationaleDialog() {
+        paparazziTestRule.snapshot {
+            ArchitectCodersTheme {
+                    RationaleDialog(
+                        title = stringResource(R.string.location_rationale_title),
+                        description = stringResource(R.string.location_rationale_description),)
+            }
+        }
+    }
+}

--- a/common/ui-resources/src/test/snapshots/images/com.ignacnic.architectcoders.common.uiresources.components_RationaleDialogTest_testRationaleDialog.png
+++ b/common/ui-resources/src/test/snapshots/images/com.ignacnic.architectcoders.common.uiresources.components_RationaleDialogTest_testRationaleDialog.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a87c7dfcef7ebe4d27dc6f9d5a311562e484f24bbd175b55c27c9553e7b2f5d2
+size 27313

--- a/feature/location/build.gradle.kts
+++ b/feature/location/build.gradle.kts
@@ -1,7 +1,9 @@
 plugins {
     alias(libs.plugins.ignacnic.android.library)
     alias(libs.plugins.ignacnic.compose)
-    alias(libs.plugins.ignacnic.test)
+    alias(libs.plugins.ignacnic.test.unit)
+    alias(libs.plugins.ignacnic.test.screenshot)
+    alias(libs.plugins.paparazzi)
 }
 
 android {

--- a/feature/location/src/main/java/com/ignacnic/architectcoders/feature/location/detail/LocationDetailScreen.kt
+++ b/feature/location/src/main/java/com/ignacnic/architectcoders/feature/location/detail/LocationDetailScreen.kt
@@ -23,13 +23,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.ignacnic.architectcoders.common.uiresources.R
 import com.ignacnic.architectcoders.common.uiresources.components.Screen
-import com.ignacnic.architectcoders.feature.location.detail.LocationDetailScreenViewModel.UiState
 import com.ignacnic.architectcoders.feature.location.detail.LocationDetailScreenViewModel.Action
-import com.ignacnic.architectcoders.common.uiresources.theme.ArchitectCodersTheme
+import com.ignacnic.architectcoders.feature.location.detail.LocationDetailScreenViewModel.UiState
 
 @Composable
 fun LocationDetailScreen(
@@ -45,7 +43,7 @@ fun LocationDetailScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun DetailContent(
+fun DetailContent(
     state: UiState,
     onBack: () -> Unit = {},
     reduce: (action: Action) -> Unit = {},
@@ -104,53 +102,5 @@ private fun DetailContent(
                 )
             }
         }
-    }
-}
-
-@Preview
-@Composable
-private fun LoadedDetailPreview() {
-    ArchitectCodersTheme {
-        DetailContent(
-            state = UiState(
-                latitude = "40.42189",
-                longitude = "-3.682189",
-                time = "0",
-                loading = false,
-                elevation = 666.0,
-            ),
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun LoadingDetailPreview() {
-    ArchitectCodersTheme {
-        DetailContent(
-            state = UiState(
-                latitude = "40.42189",
-                longitude = "-3.682189",
-                time = "0",
-                loading = true,
-                elevation = null,
-            ),
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun ErrorDetailPreview() {
-    ArchitectCodersTheme {
-        DetailContent(
-            state = UiState(
-                latitude = "40.42189",
-                longitude = "-3.682189",
-                time = "0",
-                loading = false,
-                elevation = null,
-            ),
-        )
     }
 }

--- a/feature/location/src/main/java/com/ignacnic/architectcoders/feature/location/requester/LocationRequesterScreen.kt
+++ b/feature/location/src/main/java/com/ignacnic/architectcoders/feature/location/requester/LocationRequesterScreen.kt
@@ -34,15 +34,12 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
-import com.google.accompanist.permissions.PermissionState
 import com.ignacnic.architectcoders.common.uiresources.R
 import com.ignacnic.architectcoders.common.uiresources.components.RationaleDialog
 import com.ignacnic.architectcoders.common.uiresources.components.Screen
-import com.ignacnic.architectcoders.common.uiresources.theme.ArchitectCodersTheme
 import com.ignacnic.architectcoders.common.uiresources.utils.CollectSideEffect
 import com.ignacnic.architectcoders.common.uiresources.utils.rememberDocumentPickerActivityLauncher
 import com.ignacnic.architectcoders.common.uiresources.utils.rememberDocumentTreeActivityLauncher
@@ -99,7 +96,7 @@ fun LocationRequesterScreen(
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
 @Composable
-private fun RequesterContent(
+fun RequesterContent(
     state: UiState,
     locationPermissionState: MultiplePermissionsState,
     reduce: (Action) -> Unit = {},
@@ -283,106 +280,4 @@ private fun TrashUpdatesDialog(
             ) { Text(stringResource(R.string.generic_cancel)) }
         },
     )
-}
-
-@ExperimentalPermissionsApi
-class MultiplePermissionsStatePreview : MultiplePermissionsState {
-
-    override val allPermissionsGranted: Boolean
-        get() = false
-
-    override val permissions: List<PermissionState>
-        get() = emptyList()
-
-    override val revokedPermissions: List<PermissionState>
-        get() = emptyList()
-
-    override val shouldShowRationale: Boolean
-        get() = true
-
-    override fun launchMultiplePermissionRequest() {
-        // do nothing
-    }
-}
-
-@OptIn(ExperimentalPermissionsApi::class)
-@Preview
-@Composable
-private fun EmptyRequesterPreview() {
-    ArchitectCodersTheme {
-        RequesterContent(
-            UiState(
-                locationUpdates = emptyList(),
-                updatesRunning = false,
-                locationRationaleNeeded = false,
-                updatesTrashRequested = false,
-            ),
-            MultiplePermissionsStatePreview(),
-        )
-    }
-}
-
-@OptIn(ExperimentalPermissionsApi::class)
-@Preview
-@Composable
-private fun DialogRequesterPreview() {
-    ArchitectCodersTheme {
-        RequesterContent(
-            UiState(
-                locationUpdates = emptyList(),
-                updatesRunning = false,
-                locationRationaleNeeded = true,
-                updatesTrashRequested = false,
-            ),
-            MultiplePermissionsStatePreview(),
-        )
-    }
-}
-
-@OptIn(ExperimentalPermissionsApi::class)
-@Preview
-@Composable
-private fun FilledRequesterPreview() {
-    ArchitectCodersTheme {
-        RequesterContent(
-            UiState(
-                locationUpdates = listOf(
-                    MyLocation(
-                        latitude = 40.42189,
-                        longitude = -3.682189,
-                        timeStamp = 0,
-                        elevation = 666.0
-                    )
-                ),
-                updatesRunning = true,
-                locationRationaleNeeded = false,
-                updatesTrashRequested = false,
-            ),
-            MultiplePermissionsStatePreview(),
-        )
-    }
-}
-
-@OptIn(ExperimentalPermissionsApi::class)
-@Preview
-@Composable
-private fun TrashRequestedPreview() {
-    ArchitectCodersTheme {
-        RequesterContent(
-            UiState(
-                locationUpdates = listOf(
-                    MyLocation(
-                        latitude = 40.42189,
-                        longitude = -3.682189,
-                        timeStamp = 0,
-                        elevation = 666.0
-                    )
-                ),
-                updatesRunning = true,
-                locationRationaleNeeded = false,
-                updatesTrashRequested = true,
-            ),
-            MultiplePermissionsStatePreview(),
-        )
-    }
 }

--- a/feature/location/src/test/java/com/ignacnic/architectcoders/feature/location/detail/LocationDetailScreenTest.kt
+++ b/feature/location/src/test/java/com/ignacnic/architectcoders/feature/location/detail/LocationDetailScreenTest.kt
@@ -1,0 +1,82 @@
+package com.ignacnic.architectcoders.feature.location.detail
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.Paparazzi
+import com.ignacnic.architectcoders.common.uiresources.theme.ArchitectCodersTheme
+import com.ignacnic.architectcoders.feature.location.detail.LocationDetailScreenViewModel.UiState
+import org.junit.Rule
+import org.junit.Test
+
+class LocationDetailScreenTest {
+    @get:Rule
+    val paparazziRule by lazy { Paparazzi() }
+
+    @Test
+    fun testLoadedDetailScreen() {
+        paparazziRule.snapshot {
+            ArchitectCodersTheme {
+                Box(
+                    modifier = Modifier
+                        .height(1000.dp)
+                ) {
+                    DetailContent(
+                        state = UiState(
+                            latitude = "40.42189",
+                            longitude = "-3.682189",
+                            time = "0",
+                            loading = false,
+                            elevation = 666.0,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testLoadingDetailScreen() {
+        paparazziRule.snapshot {
+            ArchitectCodersTheme {
+                Box(
+                    modifier = Modifier
+                        .height(1000.dp)
+                ) {
+                    DetailContent(
+                        state = UiState(
+                            latitude = "40.42189",
+                            longitude = "-3.682189",
+                            time = "0",
+                            loading = true,
+                            elevation = null,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testErrorDetailScreen() {
+        paparazziRule.snapshot {
+            ArchitectCodersTheme {
+                Box(
+                    modifier = Modifier
+                        .height(1000.dp)
+                ) {
+                    DetailContent(
+                        state = UiState(
+                            latitude = "40.42189",
+                            longitude = "-3.682189",
+                            time = "0",
+                            loading = false,
+                            elevation = null,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/feature/location/src/test/java/com/ignacnic/architectcoders/feature/location/requester/LocationRequesterScreenTest.kt
+++ b/feature/location/src/test/java/com/ignacnic/architectcoders/feature/location/requester/LocationRequesterScreenTest.kt
@@ -1,0 +1,92 @@
+package com.ignacnic.architectcoders.feature.location.requester
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.cash.paparazzi.Paparazzi
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.MultiplePermissionsState
+import com.google.accompanist.permissions.PermissionState
+import com.ignacnic.architectcoders.common.uiresources.theme.ArchitectCodersTheme
+import com.ignacnic.architectcoders.entities.location.MyLocation
+import com.ignacnic.architectcoders.feature.location.requester.LocationRequesterScreenViewModel.UiState
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalPermissionsApi::class)
+class LocationRequesterScreenTest {
+    @get:Rule
+    val paparazziTestRule by lazy { Paparazzi() }
+
+    @Test
+    fun testEmptyRequesterScreen() {
+        paparazziTestRule.snapshot {
+            ArchitectCodersTheme {
+                Box(
+                    modifier = Modifier
+                        .height(1000.dp),
+                ) {
+                    RequesterContent(
+                        UiState(
+                            locationUpdates = emptyList(),
+                            updatesRunning = false,
+                            locationRationaleNeeded = false,
+                            updatesTrashRequested = false,
+                        ),
+                        MultiplePermissionsStatePreview(),
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun testFilledRequesterScreen() {
+        paparazziTestRule.snapshot {
+            ArchitectCodersTheme {
+                Box(
+                    modifier = Modifier
+                        .height(1000.dp),
+                ) {
+                    RequesterContent(
+                        UiState(
+                            locationUpdates = listOf(
+                                MyLocation(
+                                    latitude = 40.42189,
+                                    longitude = -3.682189,
+                                    timeStamp = 0,
+                                    elevation = 666.0
+                                )
+                            ),
+                            updatesRunning = true,
+                            locationRationaleNeeded = false,
+                            updatesTrashRequested = false,
+                        ),
+                        MultiplePermissionsStatePreview(),
+                    )
+                }
+            }
+        }
+    }
+
+    @ExperimentalPermissionsApi
+    class MultiplePermissionsStatePreview : MultiplePermissionsState {
+
+        override val allPermissionsGranted: Boolean
+            get() = false
+
+        override val permissions: List<PermissionState>
+            get() = emptyList()
+
+        override val revokedPermissions: List<PermissionState>
+            get() = emptyList()
+
+        override val shouldShowRationale: Boolean
+            get() = true
+
+        override fun launchMultiplePermissionRequest() {
+            // do nothing
+        }
+    }
+}

--- a/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.detail_LocationDetailScreenTest_testErrorDetailScreen.png
+++ b/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.detail_LocationDetailScreenTest_testErrorDetailScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d1e64c8155b72b7826952e92e2ea6946d3ca81768f24fd0ab44ff5f83c0e3fe
+size 33061

--- a/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.detail_LocationDetailScreenTest_testLoadedDetailScreen.png
+++ b/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.detail_LocationDetailScreenTest_testLoadedDetailScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02830197a82adeb56cf6850851f57116d30a2ae1bd5b9d3588d70fd67227dc32
+size 27790

--- a/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.detail_LocationDetailScreenTest_testLoadingDetailScreen.png
+++ b/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.detail_LocationDetailScreenTest_testLoadingDetailScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd24469232e3557a5ee24889a627e9f8c8fa89261569c992b4f9a6128462b681
+size 25975

--- a/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.requester_LocationRequesterScreenTest_testEmptyRequesterScreen.png
+++ b/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.requester_LocationRequesterScreenTest_testEmptyRequesterScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2121f4592d9ab11510cf3d9f4d4bbe3776ef74624f23ccebc1c2fba4b3c985a5
+size 11466

--- a/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.requester_LocationRequesterScreenTest_testFilledRequesterScreen.png
+++ b/feature/location/src/test/snapshots/images/com.ignacnic.architectcoders.feature.location.requester_LocationRequesterScreenTest_testFilledRequesterScreen.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7acd7079462e886ed77424e82ed72748f9857c0ba1340b71a48646dfacb47fc
+size 23529

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,39 +1,42 @@
 [versions]
 accompanist = "0.37.3"
-agp = "8.11.1"
-androidGradlePlugin = "8.0.2"
+agp = "8.11.2"
+androidGradlePlugin = "8.11.2"
 gpxandroidsdk = "1.10.4"
-kotlin = "2.2.0"
-coreKtx = "1.16.0"
+kotlin = "2.2.20"
+coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
 kotlinTest = "2.2.0"
 kotlinxCoroutinesPlayServices = "1.10.2"
 kotlinxCoroutinesTest = "1.10.2"
-lifecycleRuntimeKtx = "2.9.2"
-activityCompose = "1.10.1"
-composeBom = "2025.07.00"
+lifecycleRuntimeKtx = "2.9.3"
+activityCompose = "1.11.0"
+composeBom = "2025.09.00"
 localbroadcastmanager = "28.0.0"
-loggingInterceptor = "4.12.0"
+loggingInterceptor = "5.1.0"
 mockk = "1.14.5"
-navigationCompose = "2.9.2"
-okhttp = "4.12.0"
+navigationCompose = "2.9.4"
+okhttp = "5.1.0"
 playServicesLocation = "21.3.0"
-retrofit = "2.11.0"
+retrofit = "3.0.0"
 kotlinxSerialization = "1.9.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
 detekt = "1.23.8"
-robolectric = "4.15.1"
+robolectric = "4.16"
 appcompat = "1.7.1"
-material = "1.12.0"
-jetbrainsKotlinJvm = "2.2.0"
-koin = "4.1.0"
+material = "1.13.0"
+jetbrainsKotlinJvm = "2.2.20"
+koin = "4.1.1"
+paparazzi = "2.0.0-alpha02"
 
 # Android SDK versions
-targetSdk = "35"
-compileSdk = "35"
+targetSdk = "36"
+compileSdk = "36"
 minSdk = "29"
+uiTooling = "1.9.1"
+uiToolingVersion = "1.9.1"
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }
@@ -69,24 +72,28 @@ material = { group = "com.google.android.material", name = "material", version.r
 koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koin" }
 koin-core = { group = "io.insert-koin", name  = "koin-core" }
 koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
+paparazzi = { group = "app.cash.paparazzi", name = "paparazzi", version.ref = "paparazzi" }
 
 # Gradle plugin
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "uiToolingVersion" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.2.0" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin"}
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
+paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 
 # Custom convention Plugins
 ignacnic-android-application = { id = "com.ignacnic.convention.android.application", version = "unspecified" }
 ignacnic-android-library = { id = "com.ignacnic.convention.android.library", version = "unspecified" }
 ignacnic-compose = { id = "com.ignacnic.convention.compose", version = "unspecified" }
 ignacnic-kotlin-library = { id = "com.ignacnic.convention.kotlin.library", version = "unspecified" }
-ignacnic-test = { id = "com.ignacnic.convention.test", version = "unspecified" }
+ignacnic-test-unit = { id = "com.ignacnic.convention.test.unit", version = "unspecified" }
+ignacnic-test-screenshot = { id = "com.ignacnic.convention.test.screenshot", version = "unspecified" }


### PR DESCRIPTION
In this version of the project I'm finishing the integration of tests within my project. As this has been done since the beginning, the changes are small and contained to just implementing UI tests.

For the UI tests, I've opted for the test library `paparazzi`, as it covers my needs completely. In brief, every preview that I was using to keep up with the UI changes have been translated to a snapshot test, with the focus on the UI arrangement rather that the content, this way, whenever the UI has unexpected changes, the snapshot tests will fail. The tests are based on screenshots of the different screens and reusable components, and are stored in an instance of Git-LFS to save space in the repo.